### PR TITLE
Update Flask version to fix failing code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Flask Framework
-Flask==2.0.3
+Flask==2.3.3


### PR DESCRIPTION
Upgrade the Flask version to fix the error outlined in [this ADO item](https://dev.azure.com/ceapex/Microsoft%20Learn/_workitems/edit/918495?src=WorkItemMention&src-action=artifact_link).

For more details about why this error occurred, see [this issue from the werkzeug repo](https://github.com/pallets/werkzeug/issues/2789) which upgraded the version on September 30, causing issues with the version of Flask that was previously being used in this repo.