### PR TITLE
resolve runtime error missing import (Werkzeug, implicit 2.3.x)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # Flask Framework
 Flask==2.0.3
+# and its dependencies
+Werkzeug>=2.2,<3.0


### PR DESCRIPTION
running application without the pinning down of Werkzeug dependency throws:

```
from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/home/vscode/.local/lib/python3.11/site-packages/werkzeug/urls.py)
```

as discussed in https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr